### PR TITLE
fix xo_format.5 typo

### DIFF
--- a/libxo/xo_format.5
+++ b/libxo/xo_format.5
@@ -74,7 +74,7 @@ function as an unsigned integer.
 .Ed
 .Pp
 This single line of code can generate text ("In stock: 65\\n"), XML
-("<in-stock>65</in-stock>"), JSON ('"in-stock": 6'), or HTML (too
+("<in-stock>65</in-stock>"), JSON ('"in-stock": 65'), or HTML (too
 lengthy to be listed here).
 .Ss Modifier Roles
 Modifiers are optional, and indicate the role and formatting of the


### PR DESCRIPTION
fix incorrect example output, JSON output will contain the value 65, not 6