### PR TITLE
encoding modify documentation is incorrect

### DIFF
--- a/libxo/xo_format.5
+++ b/libxo/xo_format.5
@@ -269,8 +269,8 @@ the display output styles, TEXT and HTML.
 The display modifier is the opposite of the encoding modifier, and
 they are often used to give to distinct views of the underlying data.
 .Ss The Encoding Modifier ({e:})
-The display modifier indicated the field should only be generated for
-the display output styles, TEXT and HTML.
+The encoding modifier indicated the field should only be generated for
+the encoding output styles, such as JSON and XML.
 .Bd -literal -offset indent
     EXAMPLE:
       xo_emit("{Lcw:Name}{:name} {e:id/%d}\\n", "phil", 1);


### PR DESCRIPTION
the encoding modify text is wrong, is copy/pasted from the display modifier, and actually does the opposite of what it says,