### PR TITLE
Mark xo_err*() functions as __dead2.

### DIFF
--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -272,13 +272,13 @@ void
 xo_warnx (const char *fmt, ...);
 
 void
-xo_err (int eval, const char *fmt, ...);
+xo_err (int eval, const char *fmt, ...) __dead2;
 
 void
-xo_errx (int eval, const char *fmt, ...);
+xo_errx (int eval, const char *fmt, ...) __dead2;
 
 void
-xo_errc (int eval, int code, const char *fmt, ...);
+xo_errc (int eval, int code, const char *fmt, ...) __dead2;
 
 void
 xo_message_hcv (xo_handle_t *xop, int code, const char *fmt, va_list vap);

--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -260,37 +260,37 @@ void
 xo_set_leading_xpath (xo_handle_t *xop, const char *path);
 
 void
-xo_warn_hc (xo_handle_t *xop, int code, const char *fmt, ...);
+xo_warn_hc (xo_handle_t *xop, int code, const char *fmt, ...) __printflike(3, 4);
 
 void
-xo_warn_c (int code, const char *fmt, ...);
+xo_warn_c (int code, const char *fmt, ...) __printflike(2, 3);
 
 void
-xo_warn (const char *fmt, ...);
+xo_warn (const char *fmt, ...) __printflike(1, 2);
 
 void
-xo_warnx (const char *fmt, ...);
+xo_warnx (const char *fmt, ...) __printflike(1, 2);
 
 void
-xo_err (int eval, const char *fmt, ...) __dead2;
+xo_err (int eval, const char *fmt, ...) __dead2 __printflike(2, 3);
 
 void
-xo_errx (int eval, const char *fmt, ...) __dead2;
+xo_errx (int eval, const char *fmt, ...) __dead2 __printflike(2, 3);
 
 void
-xo_errc (int eval, int code, const char *fmt, ...) __dead2;
+xo_errc (int eval, int code, const char *fmt, ...) __dead2 __printflike(3, 4);
 
 void
 xo_message_hcv (xo_handle_t *xop, int code, const char *fmt, va_list vap);
 
 void
-xo_message_hc (xo_handle_t *xop, int code, const char *fmt, ...);
+xo_message_hc (xo_handle_t *xop, int code, const char *fmt, ...) __printflike(3, 4);
 
 void
-xo_message_c (int code, const char *fmt, ...);
+xo_message_c (int code, const char *fmt, ...) __printflike(2, 3);
 
 void
-xo_message (const char *fmt, ...);
+xo_message (const char *fmt, ...) __printflike(1, 2);
 
 void
 xo_no_setlocale (void);


### PR DESCRIPTION
This way the compiler doesn't emit warnings about possible NULL pointer
dereference in cases like this:

x = malloc(...);
if (x == NULL)
	xo_err(1, ...);
x->y = 42;