### PR TITLE
fix buffer checking in xo_printf_v, xo_warn_hcv, and xo_message_hcv

### DIFF
--- a/libxo/libxo.c
+++ b/libxo/libxo.c
@@ -2995,7 +2995,7 @@ xo_format_title (xo_handle_t *xop, const char *str, int len,
 
 	} else {
 	    rc = snprintf(xbp->xb_curp, left, newfmt, newstr);
-	    if (rc > left) {
+	    if (rc >= left) {
 		if (!xo_buf_has_room(xbp, rc))
 		    return;
 		left = xbp->xb_size - (xbp->xb_curp - xbp->xb_bufp);

--- a/libxo/libxo.c
+++ b/libxo/libxo.c
@@ -860,7 +860,7 @@ xo_printf_v (xo_handle_t *xop, const char *fmt, va_list vap)
 
     rc = vsnprintf(xbp->xb_curp, left, fmt, va_local);
 
-    if (rc > xbp->xb_size) {
+    if (rc >= left) {
 	if (!xo_buf_has_room(xbp, rc)) {
 	    va_end(va_local);
 	    return -1;
@@ -1184,7 +1184,7 @@ xo_warn_hcv (xo_handle_t *xop, int code, int check_warn,
 
 	int left = xbp->xb_size - (xbp->xb_curp - xbp->xb_bufp);
 	int rc = vsnprintf(xbp->xb_curp, left, newfmt, vap);
-	if (rc > xbp->xb_size) {
+	if (rc >= left) {
 	    if (!xo_buf_has_room(xbp, rc)) {
 		va_end(va_local);
 		return;
@@ -1336,7 +1336,7 @@ xo_message_hcv (xo_handle_t *xop, int code, const char *fmt, va_list vap)
 
 	int left = xbp->xb_size - (xbp->xb_curp - xbp->xb_bufp);
 	rc = vsnprintf(xbp->xb_curp, left, fmt, vap);
-	if (rc > xbp->xb_size) {
+	if (rc >= left) {
 	    if (!xo_buf_has_room(xbp, rc)) {
 		va_end(va_local);
 		return;


### PR DESCRIPTION
When checking the return value of vsnprintf, these functions compared against the size of the buffer, rather than the number of bytes remaining in the buffer, and so fail to grow the buffer when it was insufficient to fit the new content.

Related to: 1f66642
Fixes: #37