### PR TITLE
Include stdarg.h from xo.h.

### DIFF
--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -17,6 +17,8 @@
 #ifndef INCLUDE_XO_H
 #define INCLUDE_XO_H
 
+#include <stdarg.h>
+
 /** Formatting types */
 typedef unsigned xo_style_t;
 #define XO_STYLE_TEXT	0	/** Generate text output */


### PR DESCRIPTION
xo.h uses va_list extensively, so include stdarg.h. This fixes build errors
in the libxo test code on (at least) FreeBSD 10.1-RELEASE.