### PR TITLE
Apply the __printflike attribute to xo_emit variants

### DIFF
--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -164,13 +164,13 @@ void
 xo_set_depth (xo_handle_t *xop, int depth);
 
 int
-xo_emit_hv (xo_handle_t *xop, const char *fmt, va_list vap) __printflike(2, 0);
+xo_emit_hv (xo_handle_t *xop, const char *fmt, va_list vap) PRINTFLIKE(2, 0);
 
 int
-xo_emit_h (xo_handle_t *xop, const char *fmt, ...) __printflike(2, 3);
+xo_emit_h (xo_handle_t *xop, const char *fmt, ...) PRINTFLIKE(2, 3);
 
 int
-xo_emit (const char *fmt, ...) __printflike(1, 2);
+xo_emit (const char *fmt, ...) PRINTFLIKE(1, 2);
 
 int
 xo_open_container_h (xo_handle_t *xop, const char *name);
@@ -314,7 +314,7 @@ void
 xo_errc (int eval, int code, const char *fmt, ...) NORETURN PRINTFLIKE(3, 4);
 
 void
-xo_message_hcv (xo_handle_t *xop, int code, const char *fmt, va_list vap);
+xo_message_hcv (xo_handle_t *xop, int code, const char *fmt, va_list vap) PRINTFLIKE(3, 0);
 
 void
 xo_message_hc (xo_handle_t *xop, int code, const char *fmt, ...) PRINTFLIKE(3, 4);
@@ -329,25 +329,25 @@ void
 xo_message (const char *fmt, ...) PRINTFLIKE(1, 2);
 
 void
-xo_emit_warn_hc (xo_handle_t *xop, int code, const char *fmt, ...);
+xo_emit_warn_hc (xo_handle_t *xop, int code, const char *fmt, ...) PRINTFLIKE(3, 4);
 
 void
-xo_emit_warn_c (int code, const char *fmt, ...);
+xo_emit_warn_c (int code, const char *fmt, ...) PRINTFLIKE(2, 3);
 
 void
-xo_emit_warn (const char *fmt, ...);
+xo_emit_warn (const char *fmt, ...) PRINTFLIKE(1, 2);
 
 void
-xo_emit_warnx (const char *fmt, ...);
+xo_emit_warnx (const char *fmt, ...) PRINTFLIKE(1, 2);
 
 void
-xo_emit_err (int eval, const char *fmt, ...);
+xo_emit_err (int eval, const char *fmt, ...) PRINTFLIKE(2, 3);
 
 void
-xo_emit_errx (int eval, const char *fmt, ...);
+xo_emit_errx (int eval, const char *fmt, ...) PRINTFLIKE(2, 3);
 
 void
-xo_emit_errc (int eval, int code, const char *fmt, ...);
+xo_emit_errc (int eval, int code, const char *fmt, ...)  PRINTFLIKE(3, 4);
 
 void
 xo_no_setlocale (void);

--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -164,13 +164,13 @@ void
 xo_set_depth (xo_handle_t *xop, int depth);
 
 int
-xo_emit_hv (xo_handle_t *xop, const char *fmt, va_list vap);
+xo_emit_hv (xo_handle_t *xop, const char *fmt, va_list vap) __printflike(2, 0);
 
 int
-xo_emit_h (xo_handle_t *xop, const char *fmt, ...);
+xo_emit_h (xo_handle_t *xop, const char *fmt, ...) __printflike(2, 3);
 
 int
-xo_emit (const char *fmt, ...);
+xo_emit (const char *fmt, ...) __printflike(1, 2);
 
 int
 xo_open_container_h (xo_handle_t *xop, const char *name);


### PR DESCRIPTION
This allows clang to detect type mismatches and generate proper warnings:

error: format specifies type 'char *' but the argument has type 'int' [-Werror,-Wformat]
                                xo_emit("%s", 1);
                                         ~~   ^
                                         %d