### PR TITLE
Fix comparison between signed and unsigned

### DIFF
--- a/libxo/xo_wcwidth.h
+++ b/libxo/xo_wcwidth.h
@@ -62,8 +62,8 @@
 #include <wchar.h>
 
 struct interval {
-  int first;
-  int last;
+  wchar_t first;
+  wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */


### PR DESCRIPTION
wchar_t is sometimes defined as "signed int" and sometimes
as "unsigned int". Avoid compiler warnings (that can break
the build with -Werror) by replacing int with wchar_t where
appropriate.