### PR TITLE
Fix flag for 'trim' modifier

### DIFF
--- a/libxo/xo_format.5
+++ b/libxo/xo_format.5
@@ -367,7 +367,7 @@ particular output styles:
 .It l "leaf-list    " "Field is a leaf-list, a list of leaf values"
 .It n "no-quotes    " "Do not quote the field when using JSON style"
 .It q "quotes        " "Quote the field when using JSON style"
-.It q "trim          " "Trim leading and trailing whitespace"
+.It t "trim          " "Trim leading and trailing whitespace"
 .It w "white space   " "A blank ("" "") is appended after the label"
 .El
 .Pp


### PR DESCRIPTION
Man page indicates 'q' instead of 't'
