### PR TITLE
Conditionally include AM_PROG_AR in autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_PROG_CC
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_PROG_INSTALL
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_LN_S


### PR DESCRIPTION
On systems with an automake which doesn't support AM_PROG_AR (CentOS 6,
Ubuntu 10.04), autoconf fails. Fix this by conditionally including the
macro.