### PR TITLE
Fix printing non-(ASCII/UTF-8) strings

### DIFF
--- a/libxo/libxo.c
+++ b/libxo/libxo.c
@@ -660,14 +660,7 @@ xo_init_handle (xo_handle_t *xop)
     if (!xo_locale_inited) {
 	xo_locale_inited = 1;	/* Only do this once */
 
-	const char *cp = getenv("LC_CTYPE");
-	if (cp == NULL)
-	    cp = getenv("LANG");
-	if (cp == NULL)
-	    cp = getenv("LC_ALL");
-	if (cp == NULL)
-	    cp = "C";		/* Default for C programs */
-	(void) setlocale(LC_CTYPE, cp);
+	(void) setlocale(LC_CTYPE, "");
     }
 
     /*
@@ -3510,8 +3503,9 @@ xo_do_format_field (xo_handle_t *xop, xo_buffer_t *xbp,
 			|| xf.xf_fc == 'm')) {
 
 		xf.xf_enc = (xf.xf_fc == 'm') ? XF_ENC_UTF8
-		    : (xf.xf_lflag || (xf.xf_fc == 'S')) ? XF_ENC_WIDE
-		    : xf.xf_hflag ? XF_ENC_LOCALE : XF_ENC_UTF8;
+		    : (xf.xf_lflag || xf.xf_fc == 'S') ? XF_ENC_WIDE
+		    : (xf.xf_hflag || xf.xf_fc == 's') ? XF_ENC_LOCALE
+		    : XF_ENC_UTF8;
 
 		rc = xo_format_string(xop, xbp, flags, &xf);
 


### PR DESCRIPTION
As reported in FreeBSD's PR241491, ps(1) using libxo does not display the
date in uk_UA.KOI8-U locale when invoked as `ps -o lstart` and prints
empty lines instead.  To fix it we need to assume that %s is passed in
current locale encoding.

- use XF_ENC_LOCALE for 's' format character
- pass "" to setlocale() so that if the consumer actually called setlocale()
  itself we don't overwrite already set locale; current order of environment
  variables differs from at least FreeBSD's setlocale() where the following
  order is used:
    LC_ALL
    LC_*
    LANG