### PR TITLE
Add FreeBSD to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c
 
-script: printenv && uname -a && ls -l && /bin/sh -x ./bin/setup.sh && cd build && ../configure --enable-warnings && make && sudo make install && make test
+jobs:
+  include:
+    - os: linux
+      script: printenv && uname -a && ls -l && /bin/sh -x ./bin/setup.sh && cd build && ../configure --enable-warnings && make && sudo make install && make test
+    - os: freebsd
+      script: printenv && uname -a && ls -l && /bin/sh -x ./bin/setup.sh && cd build && MAKE=gmake ../configure --enable-warnings && gmake && sudo gmake install && gmake test
 
 notifications:
   recipients:


### PR DESCRIPTION
TravisCI [supports](https://github.com/travis-ci/travis-build/pulls?q=is%3Apr+freebsd+is%3Aclosed) FreeBSD nowadays. Let's see how well it works.

This is an alterantive to #66 in case you don't want to sign up the repo with CirrusCI or maintain two CI configs.
