### PR TITLE
Escape backslash in xo_emit.3 so it renders correctly

### DIFF
--- a/libxo/xo_emit.3
+++ b/libxo/xo_emit.3
@@ -48,7 +48,7 @@ In this example, a set of four values is emitted using the following
 source code:
 .Bd  -literal -offset indent
     xo_emit(" {:lines/%7ju} {:words/%7ju} "
-            "{:characters/%7ju} {d:filename/%s}\n",
+            "{:characters/%7ju} {d:filename/%s}\en",
             linect, wordct, charct, file);
 .Ed
 Output can then be generated in various style, using 


### PR DESCRIPTION
The unescaped "\n" in xo_emit.3 generates incorrect output when rendered:

               xo_emit(" {:lines/%7ju} {:words/%7ju} "
                       "{:characters/%7ju} {d:filename/%s}0,
                       linect, wordct, charct, file);

This change escapes as "\en" so that the example code renders correctly.