### PR TITLE
Escape the newline in the example code

### DIFF
--- a/libxo/xo_create.3
+++ b/libxo/xo_create.3
@@ -33,7 +33,7 @@ function.
   Example:
     xo_handle_t *xop = xo_create(XO_STYLE_JSON, XOF_WARN);
     ....
-    xo_emit_h(xop, "testing\n");
+    xo_emit_h(xop, "testing\\n");
 .Ed
 .Pp
 By default,

--- a/libxo/xo_emit.3
+++ b/libxo/xo_emit.3
@@ -48,7 +48,7 @@ In this example, a set of four values is emitted using the following
 source code:
 .Bd  -literal -offset indent
     xo_emit(" {:lines/%7ju} {:words/%7ju} "
-            "{:characters/%7ju} {d:filename/%s}\n",
+            "{:characters/%7ju} {d:filename/%s}\\n",
             linect, wordct, charct, file);
 .Ed
 Output can then be generated in various style, using 

--- a/libxo/xo_emit_f.3
+++ b/libxo/xo_emit_f.3
@@ -84,14 +84,14 @@ clear this information; they are not generally needed.
 .Bd  -literal -offset indent
     for (i = 0; i < 1000; i++) {
         xo_open_instance("item");
-        xo_emit_f(XOEF_RETAIN, "{:name}  {:count/%d}\n",
+        xo_emit_f(XOEF_RETAIN, "{:name}  {:count/%d}\\n",
                   name[i], count[i]);
     }
 .Ed
 .Pp
 In this example, the caller desires to clear the retained information.
 .Bd  -literal -offset indent
-    const char *fmt = "{:name}  {:count/%d}\n";
+    const char *fmt = "{:name}  {:count/%d}\\n";
     for (i = 0; i < 1000; i++) {
         xo_open_instance("item");
         xo_emit_f(XOEF_RETAIN, fmt, name[i], count[i]);

--- a/libxo/xo_format.5
+++ b/libxo/xo_format.5
@@ -311,7 +311,7 @@ format descriptors default to "%s".
 .Bd -literal -offset indent
     xo_emit("{:length/%02u}x{:width/%02u}x{:height/%02u}\\n",
             length, width, height);
-    xo_emit("{:author} wrote \"{:poem}\" in {:year/%4d}\\n,
+    xo_emit("{:author} wrote \"{:poem}\" in {:year/%4d}\\n",
             author, poem, year);
 .Ed
 .Ss "The Anchor Roles ({[:} and {]:})"

--- a/libxo/xo_open_container.3
+++ b/libxo/xo_open_container.3
@@ -141,7 +141,7 @@ flag is set.
 .Bd -literal -offset indent -compact
     EXAMPLE:
        xo_open_container("system");
-       xo_emit("The host name is {:host-name}\n", hn);
+       xo_emit("The host name is {:host-name}\\n", hn);
        xo_close_container("system");
     XML:
        <system><host-name>foo</host-name></system>

--- a/libxo/xo_open_list.3
+++ b/libxo/xo_open_list.3
@@ -77,7 +77,7 @@ close each instance of the list:
 
     for (ip = list; ip->i_title; ip++) {
         xo_open_instance("item");
-        xo_emit("{L:Item} '{:name/%s}':\n", ip->i_title);
+        xo_emit("{L:Item} '{:name/%s}':\\n", ip->i_title);
         xo_close_instance("item");
     }
 
@@ -91,7 +91,7 @@ generation of XML and JSON data.
         xo_open_list("user");
         for (i = 0; i < num_users; i++) {
             xo_open_instance("user");
-            xo_emit("{k:name}:{:uid/%u}:{:gid/%u}:{:home}\n",
+            xo_emit("{k:name}:{:uid/%u}:{:gid/%u}:{:home}\\n",
                     pw[i].pw_name, pw[i].pw_uid,
                     pw[i].pw_gid, pw[i].pw_dir);
             xo_close_instance("user");
@@ -138,7 +138,7 @@ To emit a leaf list, call the
 function using the ""l"" modifier:
 .Bd -literal -offset indent -compact
     for (ip = list; ip->i_title; ip++) {
-	xo_emit("{Lwc:Item}{l:item}\n", ip->i_title);
+	xo_emit("{Lwc:Item}{l:item}\\n", ip->i_title);
     }
 .Ed
 .Pp


### PR DESCRIPTION
Escape newlines in the man pages so they render ok.