### PR TITLE
libxo/xo_syslog: fix obtaining HOST_NAME_MAX

### DIFF
--- a/libxo/xo_syslog.c
+++ b/libxo/xo_syslog.c
@@ -96,11 +96,11 @@
 #endif
 
 #ifndef HOST_NAME_MAX
-#ifdef _SC_HOST_NAME_MAX
-#define HOST_NAME_MAX _SC_HOST_NAME_MAX
+#ifdef _POSIX_HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
 #else
 #define HOST_NAME_MAX 255
-#endif /* _SC_HOST_NAME_MAX */
+#endif /* _POSIX_HOST_NAME_MAX */
 #endif /* HOST_NAME_MAX */
 
 #ifndef UNUSED
@@ -584,7 +584,7 @@ xo_vsyslog (int pri, const char *name, const char *fmt, va_list vap)
      * Add HOSTNAME; we rely on gethostname and don't fluff with
      * ip addresses.  Might need to revisit.....
      */
-    char hostname[HOST_NAME_MAX];
+    char hostname[HOST_NAME_MAX + 1];
     hostname[0] = '\0';
     if (xo_unit_test)
 	strcpy(hostname, "worker-host");


### PR DESCRIPTION
_SC_HOST_NAME_MAX has been incorrectly treated as the HOST_NAME_MAX
length.  This leads to gethostname(3) being passed an accidental value
of '72' instead of the actual maximum length allowed for the hostname.

Fall back to using _POSIX_HOST_NAME_MAX as the remaining code is not
ready for introducing sysconf(3) while _POSIX_HOST_NAME_MAX can be used
as a proper drop in replacement.

While here we fix improper accounting that could lead to hostname ending
up as an unterminated string. Documentation for gethostname(3) states:

> The gethostname() function returns the standard host name for the current
> processor, as previously set by sethostname().  The namelen argument
> specifies the size of the name array.  The returned name is null-
> terminated unless insufficient space is provided.

We can also read in the sysconf(3) manual:

> _SC_HOST_NAME_MAX
>        Maximum length of a host name (not including the terminating
>        null) as returned from the gethostname() function.

Hence, to properly store the result of gethostname(3) we need an array
of size HOST_NAME_MAX+1 to store the terminating null byte. If we fail
to do this we can end up with a non-terminated C string in situations
where the current hostname hits the limit.

Using sysconf(3) API is not a drop in replacement as that would lead to
the introduction of variable length arrays (VLA) in the code. To do this
properly we would have to call sysconf(3) to obtain hostmax length then
malloc(hostmax+1) for the hostname, remember to pass hostmax+1 to
gethostname(3) and finally to free it after use.

Sponsored by:   Fudo Security