### PR TITLE
portability fixes

### DIFF
--- a/libxo/xo_humanize.h
+++ b/libxo/xo_humanize.h
@@ -37,8 +37,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
-
 #include <sys/types.h>
 #include <assert.h>
 #include <stdio.h>

--- a/libxo/xo_syslog.c
+++ b/libxo/xo_syslog.c
@@ -38,7 +38,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/syslog.h>
@@ -58,7 +57,9 @@
 #include <stdarg.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#ifdef HAVE_SYSCTLBYNAME
 #include <sys/sysctl.h>
+#endif
 
 #include "xo_config.h"
 #include "xo.h"


### PR DESCRIPTION
this allows for easier building on non-glibc systems (and glibc 2.32+, which dropped sysctl.h)