### PR TITLE
Clean up manual pages

### DIFF
--- a/libxo/libxo-csv.7
+++ b/libxo/libxo-csv.7
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2021, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, May 2021
-.\" 
+.\"
 .Dd May 13, 2021
 .Dt LIBXO-CSV 7
 .Os
@@ -17,7 +17,8 @@
 The
 .Nm libxo
 library supports a "pluggable" encoder mechanism, and ships with an
-encoder for CSV (comma separated values) files.  The encoder allows
+encoder for CSV (comma separated values) files.
+The encoder allows
 paths and fields to be selected out of the output contents:
 .Bd -literal -offset indent
   % df --libxo @csv
@@ -48,7 +49,8 @@ To allow support for additional encodings, libxo includes a
 .Nm libxo -based
 applications can automatically use any installed encoder.
 .Pp
-Use the "encoder=XXX" option to access encoders.  The following
+Use the "encoder=XXX" option to access encoders.
+The following
 example uses the "cbor" encoder, saving the output into a file:
 .Bd -literal -offset indent
   df --libxo encoder=cbor > df-output.cbor
@@ -81,12 +83,14 @@ The string "@" can be used in place of the string "encoder=".
 .Sh The CSV (Comma Separated Values) Encoder
 .Nm libxo
 ships with a custom encoder for "CSV" files, a common format for
-comma separated values.  The output of the CSV encoder can be loaded
+comma separated values.
+The output of the CSV encoder can be loaded
 directly into spreadsheets or similar applications.
 .Pp
 A standard for CSV files is provided in RFC 4180, but since the
 format predates that standard by decades, there are many minor
-differences in CSV file consumers and their expectations.  The CSV
+differences in CSV file consumers and their expectations.
+The CSV
 encoder has a number of options to tailor output to those
 expectations.
 .Pp
@@ -150,7 +154,8 @@ In some cases, this may be unacceptable, and a specific list may be
 desired.
 .Pp
 Use the "path" option to limit the processing of output to a specific
-hierarchy.  The path should be one or more names of containers or
+hierarchy.
+The path should be one or more names of containers or
 lists.
 .Pp
 For example, if the "list-items" application generates other lists,
@@ -164,19 +169,23 @@ the user can give "path=top/data/item" as a path:
 .Ed
 .Pp
 Paths are "relative", meaning they need not be a complete set
-of names to the list.  This means that "path=item" may be sufficient
+of names to the list.
+This means that "path=item" may be sufficient
 for the above example.
 .Sh The "leafs" Option
 The CSV encoding requires that all lines of output have the same
-number of fields with the same order.  In contrast, XML and JSON allow
+number of fields with the same order.
+In contrast, XML and JSON allow
 any order (though libxo forces key leafs to appear before other
 leafs).
 .Pp
 To maintain a consistent set of fields inside the CSV file, the same
-set of leafs must be selected from each list item.  By default, the
+set of leafs must be selected from each list item.
+By default, the
 CSV encoder records the set of leafs that appear in the first list
 instance it processes, and extract only those leafs from future
-instances.  If the first instance is missing a leaf that is desired by
+instances.
+If the first instance is missing a leaf that is desired by
 the consumer, the "leaf" option can be used to ensure that an empty
 value is recorded for instances that lack a particular leaf.
 .Pp
@@ -184,7 +193,7 @@ The "leafs" option can also be used to exclude leafs, limiting the
 output to only those leafs provided.
 .Pp
 In addition, the order of the output fields follows the order in which
-the leafs are listed.  "leafs=one.two" and "leafs=two.one" give
+the leafs are listed; "leafs=one.two" and "leafs=two.one" give
 distinct output.
 .Pp
 So the "leafs" option can be used to expand, limit, and order the set
@@ -207,7 +216,7 @@ separated by a period ("."):
 .Pp
 Note that since libxo uses terminology from YANG (:RFC:`7950`), the
 data modeling language for NETCONF (:RFC:`6241`), which uses "leafs"
-as the plural form of "leaf".  libxo follows that convention.
+as the plural form of "leaf", libxo follows that convention.
 .Sh The "no-header" Option
 CSV files typical begin with a line that defines the fields included
 in that file, in an attempt to make the contents self-defining:
@@ -225,16 +234,19 @@ The csv encoder defaults to producing the header line, but the
 "no-header" option can be included to avoid the header line.
 .Sh The "no-quotes" Option
 RFC 4180 specifies that fields containing spaces should be quoted, but
-many CSV consumers do not handle quotes.  The "no-quotes" option
+many CSV consumers do not handle quotes.
+The "no-quotes" option
 instruct the CSV encoder to avoid the use of quotes.
 .Sh The "dos" Option
 RFC 4180 defines the end-of-line marker as a carriage return
-followed by a newline.  This "CRLF" convention dates from the distant
+followed by a newline.
+This "CRLF" convention dates from the distant
 past, but its use was anchored in the 1980s by the `DOS` operating
 system.
 .Pp
 The CSV encoder defaults to using the standard Unix end-of-line
-marker, a simple newline.  Use the "dos" option to use the `CRLF`
+marker, a simple newline.
+Use the "dos" option to use the `CRLF`
 convention.
 .Sh Option Handling
 The handling of command-line options is complex, since there are three
@@ -268,7 +280,7 @@ library first appeared in
 The CSV encoder first appeared in
 .Fx 13.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/libxo.3
+++ b/libxo/libxo.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 8, 2014
 .Dt LIBXO 3
 .Os
@@ -285,8 +285,9 @@ These functions are mildly compatible with their standard libc
 namesakes, but use the format string defined in
 .Xr xo_format 5 .
 While there is an increased cost for converting the strings, the
-output provided can be richer and more useful.   See also
-.Xr xo_err 3
+output provided can be richer and more useful.
+See also
+.Xr xo_err 3 .
 .It Fn xo_warn
 .It Fn xo_warnx
 .It Fn xo_warn_c
@@ -380,7 +381,6 @@ Instructs
 to use an alternative set of low-level output functions.
 .El
 .Sh SEE ALSO
-.Xr libxo-csv 7,
 .Xr xo 1 ,
 .Xr xolint 1 ,
 .Xr xo_attr 3 ,
@@ -393,7 +393,6 @@ to use an alternative set of low-level output functions.
 .Xr xo_no_setlocale 3 ,
 .Xr xo_open_container 3 ,
 .Xr xo_open_list 3 ,
-.Xr xo_options 7,
 .Xr xo_parse_args 3 ,
 .Xr xo_set_allocator 3 ,
 .Xr xo_set_flags 3 ,
@@ -401,14 +400,16 @@ to use an alternative set of low-level output functions.
 .Xr xo_set_options 3 ,
 .Xr xo_set_style 3 ,
 .Xr xo_set_writer 3 ,
-.Xr xo_format 5
+.Xr xo_format 5 ,
+.Xr libxo-csv 7 ,
+.Xr xo_options 7
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_attr.3
+++ b/libxo/xo_attr.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd July, 2014
 .Dt LIBXO 3
 .Os
@@ -26,7 +26,8 @@
 .Sh DESCRIPTION
 The
 .Fn xo_attr
-function emits attributes for the XML output style.  The attribute
+function emits attributes for the XML output style.
+The attribute
 value is recorded in the
 .Fa handle
 and is attached to the next field that is emitted via a
@@ -35,7 +36,8 @@ call.
 .Pp
 The
 .Fa name
-parameter give the name of the attribute to be encoded.  The
+parameter give the name of the attribute to be encoded.
+The
 .Fa fmt
 parameter gives a printf-style format string used to format the
 value of the attribute using any remaining arguments, or the
@@ -56,15 +58,15 @@ Since attributes are only emitted in XML, their use should be limited
 to meta-data and additional or redundant representations of data
 already emitted in other form.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_create.3
+++ b/libxo/xo_create.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -62,16 +62,16 @@ with a
 handle will release any
 resources associated with the default handle.
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
-.Xr xo_set_options 3 ,
-.Xr libxo 3
+.Xr xo_set_options 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_emit.3
+++ b/libxo/xo_emit.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -51,7 +51,7 @@ source code:
             "{:characters/%7ju} {d:filename/%s}\\n",
             linect, wordct, charct, file);
 .Ed
-Output can then be generated in various style, using 
+Output can then be generated in various style, using
 the "--libxo" option:
 .Bd  -literal -offset indent
     % wc /etc/motd
@@ -92,25 +92,26 @@ the "--libxo" option:
 .Ed
 .Sh RETURN CODE
 .Nm
-returns a negative value on error.  If the
+returns a negative value on error.
+If the
 .Nm XOF_COLUMNS
 flag has been turned on for the specific handle using
 .Xr xo_set_flags 3 ,
 then the number of display columns consumed by the output will be returned.
 .Sh SEE ALSO
-.Xr xo_open_container 3 ,
-.Xr xo_open_list 3 ,
+.Xr libxo 3 ,
 .Xr xo_emit_f 3 ,
 .Xo xo_emit_field 3 ,
-.Xr xo_format 5 ,
-.Xr libxo 3
+.Xr xo_open_container 3 ,
+.Xr xo_open_list 3 ,
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_emit_err.3
+++ b/libxo/xo_emit_err.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -66,17 +66,17 @@ parameter.
             xo_err(1, "cannot open file '%s'", filename);
 .Ed
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
-.Xr xo_format 5 ,
 .Xr xo_err 3 ,
-.Xr libxo 3
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_emit_f.3
+++ b/libxo/xo_emit_f.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2016, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, April 2016
-.\" 
+.\"
 .Dd April 15, 2016
 .Dt LIBXO 3
 .Os
@@ -30,7 +30,8 @@
 .Sh DESCRIPTION
 These functions allow callers to pass a set of flags to
 .Nm
-emitting functions.  These processing of arguments, except for
+emitting functions.
+These processing of arguments, except for
 .Fa flags ,
 is identical to the base functions.
 See
@@ -55,7 +56,8 @@ The format string must be immutable across multiple calls to
 .Xn xo_emit_f ,
 since the library retains the string.
 Typically this is done by using
-static constant strings, such as string literals. If the string is not
+static constant strings, such as string literals.
+If the string is not
 immutable, the
 .Dv XOEF_RETAIN
 flag must not be used.
@@ -100,22 +102,23 @@ In this example, the caller desires to clear the retained information.
 .Ed
 .Sh RETURN CODE
 The return values for these functions is identical to those of their
-traditional counterparts.  See
+traditional counterparts.
+See
 .Xr xo_emit 3
 for details.
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
 .Xr xo_open_container 3 ,
 .Xr xo_open_list 3 ,
-.Xr xo_format 5 ,
-.Xr libxo 3
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_emit_field.3
+++ b/libxo/xo_emit_field.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2021, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -20,7 +20,7 @@
 .Ft xo_ssize_t
 .Fn xo_emit_field "const char *rolmod" "const char *content" "const char *fmt" "const char *efmt"  "..."
 .Ft xo_ssize_t
-.Fn xo_emit_field_h "xo_handle_t *xop" "const char *rolmod" "const char *content" "const char *fmt" const char *efmt"  "..."
+.Fn xo_emit_field_h "xo_handle_t *xop" "const char *rolmod" "const char *content" "const char *fmt" "const char *efmt"  "..."
 .Ft xo_ssize_t
 .Fn xo_emit_field_hv "xo_handle_t *xop" "const char *rolmod" "const char *content" "const char *fmt" "const char *efmt" "va_list vap"
 .Sh DESCRIPTION
@@ -56,7 +56,8 @@ in pieces, rather than having to use something like
 .Xr snprintf 3
 to build the format string required by
 .Fn xo_emit .
-The arguments are each NUL-terminated strings. The
+The arguments are each NUL-terminated strings.
+The
 .Fa rolmod
 argument contains the "role" and "modifier" portions of
 the field description, the
@@ -94,20 +95,22 @@ source code:
 .Ed
 .Sh RETURN CODE
 .Nm
-returns a negative value on error.  If the
+returns a negative value on error.
+If the
 .Nm XOF_COLUMNS
 flag has been turned on for the specific handle using
 .Xr xo_set_flags 3 ,
 then the number of display columns consumed by the output will be returned.
 .Sh SEE ALSO
-.Xr xo_format 5 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .

--- a/libxo/xo_err.3
+++ b/libxo/xo_err.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -49,7 +49,8 @@ argument is one compatible with
 .Xr printf 3
 rather than
 .Xr xo_emit 3
-to aid in simple conversion.  This means
+to aid in simple conversion.
+This means
 these functions make unstructured data.
 To generate structured data,
 use the
@@ -69,16 +70,16 @@ parameter.
             xo_err(1, "cannot open file '%s'", filename);
 .Ed
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
-.Xr xo_emit_err 3 ,
-.Xr libxo 3
+.Xr xo_emit_err 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_error.3
+++ b/libxo/xo_error.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -23,7 +23,7 @@
 Use the
 .Fn xo_error
 function to generate error messages to standard error.
-The 
+The
 .Fa fmt
 argument is a string containing printf-style formatting
 instructions that describe the remaining arguments.
@@ -31,21 +31,21 @@ instructions that describe the remaining arguments.
 When converting an application to
 .Nm libxo ,
 one can replace
-.Em "fprintf(stderr,...)"
+.Em "fprintf(stderr, ...)"
 calls with
 .Fn xo_error
 calls.
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr printf 3 ,
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_finish.3
+++ b/libxo/xo_finish.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -35,15 +35,15 @@ Calling this function is
 to the proper operation of libxo,
 especially for the non-TEXT output styles.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_flush.3
+++ b/libxo/xo_flush.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -31,15 +31,15 @@ The
 .Fn xo_flush
 function is used for this.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_format.5
+++ b/libxo/xo_format.5
@@ -300,7 +300,7 @@ Units can also be rendered in HTML as the "data\-units" attribute:
          data\-xpath="/top/data/distance">50</div>
 .Ed
 .Ss "The Value Role ({V:} and {:})"
-The value role is used to represent the a data value that is
+The value role is used to represent the data value that is
 interesting for the non\-display output styles (XML and JSON).
 Value
 is the default role; if no other role designation is given, the field
@@ -318,7 +318,7 @@ format descriptors default to "%s".
 .Bd -literal -offset indent
     xo_emit("{:length/%02u}x{:width/%02u}x{:height/%02u}\\n",
             length, width, height);
-    xo_emit("{:author} wrote \"{:poem}\" in {:year/%4d}\\n,
+    xo_emit("{:author} wrote \"{:poem}\" in {:year/%4d}\\n",
             author, poem, year);
 .Ed
 .Ss "The Anchor Roles ({[:} and {]:})"
@@ -531,8 +531,9 @@ for the HTML output style when
 is set, but other uses are likely in the near future.
 .Ss "The Leaf\-List Modifier ({l:})"
 The leaf\-list modifier is used to distinguish lists where each
-instance consists of only a single value.  In XML, these are
-rendered as single elements, where JSON renders them as arrays.
+instance consists of only a single value.
+In XML, these are
+rendered as single elements, whereas JSON renders them as arrays.
 .Bd -literal -offset indent
     EXAMPLE:
         xo_open_list("user");
@@ -969,8 +970,8 @@ use only one of the field names.
 If there is a difference, change the
 names to make that difference more obvious.
 .Sh SEE ALSO
-.Xr libxo 3 ,
 .Xr xolint 1 ,
+.Xr libxo 3 ,
 .Xr xo_emit 3
 .Sh HISTORY
 The
@@ -978,7 +979,7 @@ The
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_message.3
+++ b/libxo/xo_message.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -28,13 +28,18 @@
 .Ft void
 .Fn xo_message_hcv "xo_handle_t *xop" "int code" "const char *fmt" "va_list vap"
 .Sh DESCRIPTION
+The
 .Nm xo_message
-generates text message which lack any sort of structure.
+function generates text messages which lack any sort of structure.
 These functions should not be used under normal conditions, since
-they completely defeat the value of using libxo.  They are provided
+they completely defeat the value of using libxo.
+They are provided
 for scenarios when the output's content is genuinely unknown and
 unusable.
-It is used in converting programs where err/warn where not used,
+It is used in converting programs where
+.Xr err 3 /
+.Xr warn 3
+were not used,
 and error messages went to
 .Nm stdout ,
 not
@@ -46,14 +51,17 @@ the error in a useful form.
 .Pp
 The
 .Nm xo_message
-function generates output strings using the printf-style format string
+function generates output strings using the
+.Xr printf 3 Ns
+-style format string
 and arguments provided.
 If the format string does not end in a newline,
 .Nm xo_message_e
-will appear a colon, a space, and the error associated with the current
+will emit a colon, a space, and the error associated with the current
 .Nm errno
 value.
-.Nm xo_message_c behaves similarly for the value passed in the
+.Nm xo_message_c
+behaves similarly for the value passed in the
 .Fa code
 parameter.
 .Nm xo_message_hc
@@ -62,17 +70,20 @@ accepts a
 as opened by
 .Xr xo_create 3
 and
-.Nm xo_message_hcv accepts a va_list parameter of arguments.
+.Nm xo_message_hcv
+accepts a
+.Vt va_list
+of arguments.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_no_setlocale.3
+++ b/libxo/xo_no_setlocale.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -36,18 +36,18 @@ can do so by calling the
 .Fn xo_no_setlocale
 function.
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
 .Xr xo_open_container 3 ,
 .Xr xo_open_list 3 ,
-.Xr xo_format 5 ,
-.Xr libxo 3
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_open_container.3
+++ b/libxo/xo_open_container.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -63,7 +63,7 @@ functions.
 Each open call should have a matching close call.
 If the
 .Dv XOF_WARN
-flag is set and the name given does not match the name of 
+flag is set and the name given does not match the name of
 the currently open
 container, a warning will be generated.
 .Bd -literal -offset indent -compact
@@ -184,15 +184,15 @@ containers, lists, and instances.
 A warning is generated when the name given to the close function
 and the name recorded do not match.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_open_list.3
+++ b/libxo/xo_open_list.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -144,7 +144,8 @@ function using the ""l"" modifier:
 .Pp
 The name of the field must match the name of the leaf list.
 .Pp
-In JSON, leaf lists are rendered as arrays of values.  In XML, they
+In JSON, leaf lists are rendered as arrays of values.
+In XML, they
 are rendered as multiple leaf elements.
 .Bd -literal -offset indent -compact
     JSON:
@@ -154,15 +155,15 @@ are rendered as multiple leaf elements.
         <item>nail</item>
 .Ed
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_open_marker.3
+++ b/libxo/xo_open_marker.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, January 2015
-.\" 
+.\"
 .Dd January 22, 2015
 .Dt LIBXO 3
 .Os
@@ -34,7 +34,7 @@ and
 A marker can be used to affect how open constructs are closed, either
 by preventing their (implicit or explicit) closure or by forcing their
 closure.
-While a marker is open, no other open constructs can be closed. 
+While a marker is open, no other open constructs can be closed.
 When a marker is closed, all constructs open since the marker was opened
 will be closed.
 A marker is used to "freeze" any open constructs.
@@ -89,7 +89,8 @@ opened after the "outer" marker.
 .Ed
 .Pp
 In this example, the code whiffles through a list of fish, calling a
-function to emit details about each fish.  The marker "fish-guts" is
+function to emit details about each fish.
+The marker "fish-guts" is
 used to ensure that any constructs opened by the function are closed
 properly.
 .Bd -literal -offset indent
@@ -101,15 +102,15 @@ properly.
     }
 .Ed
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_options.7
+++ b/libxo/xo_options.7
@@ -68,7 +68,7 @@ The brief options are a set of single\-letter aliases for the longer
 terms, used as a single string:
 .Bl -column "Value" "Equivalent Token"
 .It Sy "Value" "Equivalent Token"
-.It "c 
+.It "c
 .It "f     " "flush"
 .It "F     " "flush\-line"
 .It "H     " "html"
@@ -151,6 +151,7 @@ The
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .

--- a/libxo/xo_parse_args.3
+++ b/libxo/xo_parse_args.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd November 17, 2020
 .Dt LIBXO 3
 .Os
@@ -65,16 +65,16 @@ Note that the value is not copied, so the memory passed to
 must be maintained by the caller.
 .Pp
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_emit 3 ,
-.Xr xo_options 7,
-.Xr libxo 3
+.Xr xo_options 7
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_allocator.3
+++ b/libxo/xo_set_allocator.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -50,15 +50,15 @@ and
 .Xr free 3
 functions are used.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_flags.3
+++ b/libxo/xo_set_flags.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -133,17 +133,17 @@ the value "key".
 The
 .Fn xo_clear_flags
 function turns off the given flags in a specific
-handle. 
+handle.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_info.3
+++ b/libxo/xo_set_info.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -94,19 +94,19 @@ command line argument.
 The type and help values, if present, are emitted as the "data-type"
 and "data-help" attributes:
 .Bd -literal -offset indent
-  <div class="data" data-tag="sku" data-type="string" 
+  <div class="data" data-tag="sku" data-type="string"
        data-help="Stock Keeping Unit">GRO-000-533</div>
 .Ed
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_options.3
+++ b/libxo/xo_set_options.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -27,15 +27,15 @@ and flags and enables them for a specific handle.
 The options are identical to those listed in
 .Xr xo_parse_args 3 .
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_style.3
+++ b/libxo/xo_set_style.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -49,15 +49,15 @@ The name can be any of the styles: "text", "xml", "json", or "html".
         xo_set_style_name(NULL, "html");
 .Ed
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_syslog_enterprise_id.3
+++ b/libxo/xo_set_syslog_enterprise_id.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2015
-.\" 
+.\"
 .Dd July 20, 2015
 .Dt LIBXO 3
 .Os
@@ -32,15 +32,15 @@ defined by IANA, the Internet Assigned Numbers Authority:
 https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
 .Ed
 .Sh SEE ALSO
-.Xr xo_syslog 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_syslog 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_version.3
+++ b/libxo/xo_set_version.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -30,15 +30,15 @@ This version number is suitable for tracking changes in the content,
 allowing a user of the data to discern which version of the data model
 is in use.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_set_writer.3
+++ b/libxo/xo_set_writer.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt LIBXO 3
 .Os
@@ -52,15 +52,15 @@ The
 function should
 flush any pending data associated with the opaque pointer.
 .Sh SEE ALSO
-.Xr xo_emit 3 ,
-.Xr libxo 3
+.Xr libxo 3 ,
+.Xr xo_emit 3
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/libxo/xo_syslog.3
+++ b/libxo/xo_syslog.3
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2015
-.\" 
+.\"
 .Dd July 20, 2015
 .Dt LIBXO 3
 .Os
@@ -73,17 +73,17 @@ function names.
               iut, source, id);
 .Ed
 .Sh SEE ALSO
+.Xr libxo 3 ,
 .Xr xo_syslog 3 ,
 .Xr xo_set_syslog_enterprise_id 3 ,
-.Xr xo_format 5 ,
-.Xr libxo 3
+.Xr xo_format 5
 .Sh HISTORY
 The
 .Nm libxo
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/xo/xo.1
+++ b/xo/xo.1
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt XO 1
 .Os
@@ -34,48 +34,48 @@ or
 using the same commands that emit text output.
 .Pp
 .Bl -tag -width indent
-.It Ic --close Ar path
+.It Fl -close Ar path
 Close tags for the given path
-.It Ic -C | Ic --continuation
+.It Fl C | Fl -continuation
 Indicates this output is a continuation of the previous output data
 and should appear on the same line.
 This is allows HTML output to be constructed correctly.
-.It Ic --depth Ar num
+.It Fl -depth Ar num
 Set the depth for pretty printing
-.It Ic --help
+.It Fl -help
 Display help text
-.It Ic -H | Ic --html
+.It Fl H | Fl -html
 Generate HTML output
-.It Ic -J | Ic --json
+.It Fl J | Fl -json
 Generate JSON output
-.It Ic --leading-xpath Ar path
+.It Fl -leading-xpath Ar path
 Add a prefix to generated XPaths (HTML)
-.It Ic --not-first
+.It Fl -not-first
 Indicate that this content is not the first in a series of sibling
 objects, which is vital information for "JSON" output, which requires
 a comma between such objects.
-.It Ic --open Ar path
+.It Fl -open Ar path
 Open tags for the given path
-.It Ic -p | Ic --pretty
+.It Fl p | Fl -pretty
 Make 'pretty' output (add indent, newlines)
-.It Ic --style Ar style
+.It Fl -style Ar style
 Generate given style (xml, json, text, html)
-.It Ic -T | Ic --text
+.It Fl T | Fl -text
 Generate text output (the default style)
-.It Ic --top-warp
+.It Fl -top-warp
 Indicates the entire object should be placed inside a top-level
 object wrapper, specifically when generating JSON output.
-.It Ic --version
+.It Fl -version
 Display version information
-.It Ic -W | Ic --warn
+.It Fl W | Fl -warn
 Display warnings in text on stderr
-.It Ic --warn-xml
+.It Fl -warn-xml
 Display warnings in xml on stdout
-.It Ic --wrap Ar path
+.It Fl -wrap Ar path
 Wrap output in a set of containers
-.It Ic -X | Ic --xml
+.It Fl X | Fl -xml
 Generate XML output
-.It Ic --xpath
+.It Fl -xpath
 Add XPath data to HTML output
 .El
 .Pp
@@ -205,7 +205,7 @@ The
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/xohtml/xohtml.1
+++ b/xohtml/xohtml.1
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt XOHTML 1
 .Os
@@ -16,11 +16,11 @@
 .Xr xo_emit 3
 .Sh SYNOPSIS
 .Nm xohtml
-.Op Fl "b <base>"
-.Op Fl "c" <command>"
-.Op Fl "f" <output>
-.Op Fl "w"
-.Op Ar command [argument ...]
+.Op Fl b Ar base
+.Op Fl c Ar command
+.Op Fl f Ar output
+.Op Fl w
+.Op Ar command Op Ar argument ...
 .Sh DESCRIPTION
 .Nm
 is a tool for preparing
@@ -41,36 +41,34 @@ standard input is used.
 is typically used to wrap
 .Nm libxo
 output with sufficient HTML content to allow display in a web browser.
-This includes parent HTML tags as well as
-.Nm CSS
-stylesheets and
-.Nm Javascript
-files.
+This includes parent HTML tags as well as CSS stylesheets and
+Javascript files.
 .Pp
 If the command is given directly on the command line,
 .Nm
 will add the "--libxo=html" option needed to generate HTML output
 from
-.Nm libxo "-enabled"
-applications.  See
+.Nm libxo Ns
+-enabled applications.
+See
 .Xr xo_options 7
 for details.
 .Pp
 The following options are available:
 .Bl -tag -width indent
-.It Ic -b Ar base | Ic --base Ar base
+.It Fl b Ar base | Fl -base Ar base
 Supplies a source path for the CSS and Javascript files referenced in
 the output of
 .Nm xohtml .
-.It Ic -c Ar command | Ic --command Ar command
+.It Fl c Ar command | Fl -command Ar command
 Use the given command instead of one on the command line.
 This command should be quoted if it consists of multiple tokens, and
 should contain the "--libxo=html" option or equivalent, since the
 command is used directly.
-.It Ic -f Ar file | Ic --file Ar file
+.It Fl f Ar file | Fl -file Ar file
 Output is saved to the given file, rather than to the standard output
 descriptor.
-.It Ic -w | --web
+.It Fl w | --web
 Uses the official
 .Nm libxo
 website URL as the source path for the CSS and Javascript files
@@ -101,3 +99,13 @@ the output to /tmp/src.html:
 .Xr libxo 3 ,
 .Xr xo_emit 3 ,
 .Xr xo_options 7
+.Sh HISTORY
+The
+.Nm libxo
+library first appeared in
+.Fx 11.0 .
+.Sh AUTHORS
+The
+.Nm libxo
+library was written by
+.An Phil Shafer Aq Mt phil@freebsd.org .

--- a/xolint/xolint.1
+++ b/xolint/xolint.1
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2014, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2014
-.\" 
+.\"
 .Dd December 4, 2014
 .Dt XOLINT 1
 .Os
@@ -17,14 +17,14 @@
 .Sh SYNOPSIS
 .Nm xolint
 .Op Fl c
-.Op Fl "C <flags>"
-.Op Fl "d"
-.Op Fl "D"
-.Op Fl "I"
-.Op Fl "p"
-.Op Fl "V"
-.Op Fl "X"
-.Op Ar files...
+.Op Fl C Ar flags
+.Op Fl d
+.Op Fl D
+.Op Fl I
+.Op Fl p
+.Op Fl V
+.Op Fl X
+.Op Ar files ...
 .Sh DESCRIPTION
 .Nm
 is a tool for reporting common mistakes in format strings
@@ -39,26 +39,26 @@ error, warning, or informational messages as needed.
 .Bl -tag -width "C <flags>"
 .It Fl c
 Invoke 'cpp' against the input file
-.It Fl "C <flags>"
+.It Fl C Ar flags
 Flags that are passed to 'cpp'
-.It Fl "d"
+.It Fl d
 Enable debug output
-.It Fl "D"
+.It Fl D
 Generate documentation for all
 .Nm
 messages
-.It Fl "I"
+.It Fl I
 Generate a table of
 .Dv xo_info_t
 structures.
-.It Fl "p"
+.It Fl p
 Print the offending lines after the error message is displayed
-.It Fl "V"
+.It Fl V
 Do not report errors, but instead print a complete list of
 all field names, sorted alphabetically.
 The output can help spot
 inconsistencies and spelling errors.
-.It Fl "X"
+.It Fl X
 Extract samples from
 .Nm ,
 suitable for internal testing.
@@ -83,7 +83,7 @@ The
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-

--- a/xopo/xopo.1
+++ b/xopo/xopo.1
@@ -2,11 +2,11 @@
 .\" # Copyright (c) 2015, Juniper Networks, Inc.
 .\" # All rights reserved.
 .\" # This SOFTWARE is licensed under the LICENSE provided in the
-.\" # ../Copyright file. By downloading, installing, copying, or 
+.\" # ../Copyright file. By downloading, installing, copying, or
 .\" # using the SOFTWARE, you agree to be bound by the terms of that
 .\" # LICENSE.
 .\" # Phil Shafer, July 2015
-.\" 
+.\"
 .Dd July 9, 2015
 .Dt XOPO 1
 .Os
@@ -54,17 +54,17 @@ output stream, allowing
 to operated as a filter.
 .Pp
 .Bl -tag -width indent
-.It Ic -f Ar pofile | Ic --po  Ar pofile
+.It Fl f Ar pofile | Fl -po  Ar pofile
 Use the given po file for input.
-.It Ic --help
+.It Fl -help
 Display this help text
-.It Ic -o Ar file | Ic --output Ar file
+.It Fl o Ar file | Fl -output Ar file
 Write output content to the given file
-.It Ic -s Ar text | Ic --simplify Ar text
+.It Fl s Ar text | Fl -simplify Ar text
 Generate the simplified version of a single text string.
-.It Ic -W | Ic --warn
+.It Fl W | Fl -warn
 Generate warnings while parsing the format strings
-.It Ic --version
+.It Fl -version
 Display version information
 .El
 .Pp
@@ -81,7 +81,7 @@ The
 library first appeared in
 .Fx 11.0 .
 .Sh AUTHORS
+The
 .Nm libxo
-was written by
+library was written by
 .An Phil Shafer Aq Mt phil@freebsd.org .
-


### PR DESCRIPTION
* Trim trailing whitespace and blank lines.
* Always start a sentence on a new line.
* Order SEE ALSO section by section first, then lexically by title.
* Consistent HISTORY and AUTHORS sections.
* Correct markup for command-line options.
* Fix missing quotes.

This is by no means exhaustive, and some pages (e.g. libxo-csv) need a lot of help, but it's a start.