### PR TITLE
libxo/*.h fix libxo header include when the source is C++

### DIFF
--- a/libxo/xo.h
+++ b/libxo/xo.h
@@ -20,6 +20,10 @@
 #ifndef INCLUDE_XO_H
 #define INCLUDE_XO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <stdarg.h>
@@ -735,5 +739,9 @@ xo_map_add_file (xo_handle_t *xop, const char *fname);
 
 int
 xo_filter_add (xo_handle_t *xop, const char *vp);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* INCLUDE_XO_H */

--- a/libxo/xo_encoder.h
+++ b/libxo/xo_encoder.h
@@ -18,6 +18,10 @@
 #ifndef XO_ENCODER_H
 #define XO_ENCODER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <string.h>
 
 #include "xo_private.h"
@@ -207,5 +211,9 @@ xo_whiteboard_op_name (xo_whiteboard_op_t op);
  */
 void
 xo_failure (xo_handle_t *xop, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* XO_ENCODER_H */


### PR DESCRIPTION
C++ needs extern C to disable C++ name mangling.
To use libxo in C++ it is better to include extern "C" guardian