### PR TITLE
Fix Linux build (C23 bool, strlcpy, parallel yacc header, gettext/msgfmt, byacc)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,11 +209,20 @@ HAVE_GETTEXT=no
 
 if test "$GETTEXT_ENABLE" != "no"; then
 
+  dnl glibc provides gettext in libc; only link -lintl when a separate
+  dnl libintl is required (e.g. macOS, *BSD), so detection also works on glibc.
+  GETTEXT_INTL=-lintl
+  AC_LINK_IFELSE([AC_LANG_SOURCE([[#include <libintl.h>]
+             [#include <stddef.h>]
+             [int main() {char *cp = dgettext(NULL, "xx"); return 0; }]])],
+                 [GETTEXT_INTL=])
+
   AC_MSG_CHECKING([gettext in ${GETTEXT_PREFIX}])
 
   _save_cflags="$CFLAGS"
-  CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror -lintl"
+  CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror ${GETTEXT_INTL}"
   AC_LINK_IFELSE([AC_LANG_SOURCE([[#include <libintl.h>]
+             [#include <stddef.h>]
              [int main() {char *cp = dgettext(NULL, "xx"); return 0; }]])],
              [HAVE_GETTEXT=yes],
              [HAVE_GETTEXT=no])
@@ -226,8 +235,9 @@ if test "$GETTEXT_ENABLE" != "no"; then
       AC_MSG_CHECKING([gettext in ${GETTEXT_PREFIX}])
 
       _save_cflags="$CFLAGS"
-      CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror -lintl"
+      CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror ${GETTEXT_INTL}"
       AC_LINK_IFELSE([AC_LANG_SOURCE([[#include <libintl.h>]
+             [#include <stddef.h>]
                  [int main() {char *cp = dgettext(NULL, "xx"); return 0; }]])],
                  [HAVE_GETTEXT=yes],
                  [HAVE_GETTEXT=no])
@@ -241,8 +251,9 @@ if test "$GETTEXT_ENABLE" != "no"; then
       AC_MSG_CHECKING([gettext in ${GETTEXT_PREFIX}])
 
       _save_cflags="$CFLAGS"
-      CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror -lintl"
+      CFLAGS="$CFLAGS -I${GETTEXT_PREFIX}/include -L${GETTEXT_PREFIX}/lib -Werror ${GETTEXT_INTL}"
       AC_LINK_IFELSE([AC_LANG_SOURCE([[#include <libintl.h>]
+             [#include <stddef.h>]
                  [int main() {char *cp = dgettext(NULL, "xx"); return 0; }]])],
                  [HAVE_GETTEXT=yes],
                  [HAVE_GETTEXT=no])
@@ -255,7 +266,7 @@ fi
 if test "$HAVE_GETTEXT" = "yes"; then
     AC_DEFINE([HAVE_GETTEXT], [1], [gettext(3)])
     GETTEXT_CFLAGS="-I${GETTEXT_PREFIX}/include"
-    GETTEXT_LIBS="-L${GETTEXT_PREFIX}/lib -lintl"
+    GETTEXT_LIBS="-L${GETTEXT_PREFIX}/lib ${GETTEXT_INTL}"
 else
     GETTEXT_PREFIX=none
     GETTEXT_CFLAGS=
@@ -266,14 +277,17 @@ AC_SUBST(GETTEXT_LIBS)
 
 GETTEXT_LIBDIR=${GETTEXT_PREFIX}/lib
 AC_SUBST(GETTEXT_LIBDIR)
-if test -x ${GETTEXT_PREFIX}/bin/msgfmt ; then
+if test "$HAVE_GETTEXT" != "yes"; then
+    GETTEXT_BINDIR=
+elif test -x ${GETTEXT_PREFIX}/bin/msgfmt ; then
     GETTEXT_BINDIR=${GETTEXT_PREFIX}/bin
 elif test -x ${GETTEXT_PREFIX}/local/bin/msgfmt ; then
     GETTEXT_BINDIR=${GETTEXT_PREFIX}/local/bin
 else
-    AC_MSG_FAILURE("could not find msgfmt tool")
-    # Use a (bad) fall back value
-    GETTEXT_BINDIR=${GETTEXT_PREFIX}/bin
+    dnl gettext may live in libc (glibc); msgfmt can be elsewhere on PATH
+    AC_PATH_PROG([MSGFMT], [msgfmt])
+    AS_IF([test -n "$MSGFMT"], [GETTEXT_BINDIR=`AS_DIRNAME([$MSGFMT])`],
+          [AC_MSG_FAILURE([could not find msgfmt tool])])
 fi
 AC_SUBST(GETTEXT_BINDIR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,15 @@ AC_PATH_PROG(MKDIR, mkdir, /bin/mkdir)
 AC_PATH_PROG(MV, mv, /bin/mv)
 AC_PATH_PROG(RM, rm, /bin/rm)
 AC_PATH_PROG(SED, sed, /bin/sed)
-AC_CHECK_PROGS(YACC, [byacc yacc 'bison -y'], )
+AC_CHECK_PROGS(YACC, [byacc yacc], )
+
+dnl The XPath grammar relies on byacc extensions (a reentrant parser
+dnl exposing yystate and byacc-generated tables) that GNU bison does not
+dnl provide, so require byacc instead of silently using an incompatible bison.
+AS_IF([test -z "$YACC"],
+  [AC_MSG_ERROR([byacc is required to build the XPath filter; please install byacc])])
+AS_IF([$YACC --version 2>/dev/null | grep -qi bison],
+  [AC_MSG_ERROR([byacc is required to build the XPath filter; the detected yacc is GNU bison, which is not compatible. Please install byacc])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/filter/Makefile.am
+++ b/filter/Makefile.am
@@ -65,7 +65,7 @@ CLEANFILES = \
     xo_xpath.tab.h \
     xo_xpath.output
 
-xo_xparse.o xo_filter.o xo_xparse.lo xo_filter.lo: xo_xpath.tab.h
+xo_xpath.o xo_xpath.lo xo_xparse.o xo_filter.o xo_xparse.lo xo_filter.lo: xo_xpath.tab.h
 
 EXTRA_DIST = \
     xo_xpath.y

--- a/filter/xo_filter.c
+++ b/filter/xo_filter.c
@@ -1780,16 +1780,16 @@ xo_eval_op_and (XO_EVAL_OP_ARGS)
 {
     xo_eval_value_t value = xo_eval_value_make(C_BOOLEAN, 0, 0);
 
-    int bool = xo_eval_cast_boolean(xop, left);
-    if (!bool && !(left.xev_flags & XEVF_MISSING)) {
+    int boolval = xo_eval_cast_boolean(xop, left);
+    if (!boolval && !(left.xev_flags & XEVF_MISSING)) {
 	value.xev_int64 = 0;
 	value.xev_flags |= XEVF_FINAL;
 
 	return value;
     }
 
-    bool = xo_eval_cast_boolean(xop, right);
-    if (!bool) {
+    boolval = xo_eval_cast_boolean(xop, right);
+    if (!boolval) {
 	value.xev_int64 = 0;
 	value.xev_flags |= XEVF_FINAL;
 
@@ -1805,16 +1805,16 @@ xo_eval_op_or (XO_EVAL_OP_ARGS)
 {
     xo_eval_value_t value = xo_eval_value_make(C_BOOLEAN, 0, 0);
 
-    int bool = xo_eval_cast_boolean(xop, left);
-    if (bool) {
+    int boolval = xo_eval_cast_boolean(xop, left);
+    if (boolval) {
 	value.xev_int64 = 1;
 	value.xev_flags |= XEVF_FINAL;
 
 	return value;
     }
 
-    bool = xo_eval_cast_boolean(xop, right);
-    if (bool) {
+    boolval = xo_eval_cast_boolean(xop, right);
+    if (boolval) {
 	value.xev_int64 = 1;
 	value.xev_flags |= XEVF_FINAL;
 
@@ -2003,10 +2003,10 @@ xo_eval_not (XO_EVAL_NODE_ARGS)
     if (value.xev_flags & XEVF_MISSING)
 	return value;
 
-    int bool = xo_eval_cast_boolean(xop, value);
+    int boolval = xo_eval_cast_boolean(xop, value);
     xo_eval_value_free(value);
     value.xev_type = C_BOOLEAN;
-    value.xev_int64 = bool ? 0 : 1; /* Perform the 'not' */
+    value.xev_int64 = boolval ? 0 : 1; /* Perform the 'not' */
     return value;
 }
 
@@ -2126,10 +2126,10 @@ xo_eval_func_false (XO_EVAL_NODE_ARGS)
 static xo_eval_value_t
 xo_eval_func_boolean (XO_EVAL_NODE_ARGS)
 {
-    int bool = xo_eval_cast_boolean(xop, argv[0]);
+    int boolval = xo_eval_cast_boolean(xop, argv[0]);
 
     xo_eval_value_t value = XO_EVAL_VALUE_BOOLEAN_FALSE;
-    value.xev_int64 = bool ? 1 : 0;
+    value.xev_int64 = boolval ? 1 : 0;
     return value;
 }
 
@@ -2183,9 +2183,9 @@ xo_eval_func_normalize_space (XO_EVAL_NODE_ARGS)
 static xo_eval_value_t
 xo_eval_func_not (XO_EVAL_NODE_ARGS)
 {
-    int bool = xo_eval_cast_boolean(xop, argv[0]);
+    int boolval = xo_eval_cast_boolean(xop, argv[0]);
     xo_eval_value_t value = XO_EVAL_VALUE_BOOLEAN_FALSE;
-    value.xev_int64 = bool ? 0 : 1;
+    value.xev_int64 = boolval ? 0 : 1;
     return value;
 }
 
@@ -2336,7 +2336,7 @@ xo_eval_func_choose (XO_EVAL_NODE_ARGS)
 	return xo_eval_value_missing();
     }
 
-    int bool = xo_eval_cast_boolean(xop, cond);
+    int boolval = xo_eval_cast_boolean(xop, cond);
     xo_eval_value_free(cond);
 
     /* Locate the then and else node ids */
@@ -2344,8 +2344,8 @@ xo_eval_func_choose (XO_EVAL_NODE_ARGS)
     xnp = xo_xparse_node(&xfp->xf_xd, then_id);
     xo_xparse_node_id_t else_id = xnp->xn_next;
 
-    xo_xparse_node_id_t branch_id = bool ? then_id : else_id;
-    return xo_eval(xop, xfp, framep, bool ? "choose-then" : "choose-else",
+    xo_xparse_node_id_t branch_id = boolval ? then_id : else_id;
+    return xo_eval(xop, xfp, framep, boolval ? "choose-then" : "choose-else",
 		   indent + XO_INDENT, branch_id, NULL);
 }
 

--- a/libxo/xo_syslog.c
+++ b/libxo/xo_syslog.c
@@ -586,7 +586,7 @@ xo_vsyslog (int pri, const char *name, const char *fmt, va_list vap)
     char hostname[XO_HOST_NAME_MAX + 1];
     hostname[0] = '\0';
     if (xo_unit_test)
-	strlcpy(hostname, "worker-host", sizeof(hostname));
+	snprintf(hostname, sizeof(hostname), "%s", "worker-host");
     else
 	(void) gethostname(hostname, sizeof(hostname) - 1);
     hostname[XO_HOST_NAME_MAX] = '\0'; /* Ensure NUL-terminated */

--- a/tests/gettext/gt_01.c
+++ b/tests/gettext/gt_01.c
@@ -47,14 +47,14 @@ main (int argc, char **argv)
 	else if (xo_streq(argv[argc], "lang"))
 	    lang = argv[++argc];
 	else if (xo_streq(argv[argc], "po"))
-	    strlcpy(path, argv[++argc], sizeof(path));
+	    snprintf(path, sizeof(path), "%s", argv[++argc]);
 	else if (xo_streq(argv[argc], "sub"))
 	    sub = argv[++argc];
     }
 
     if (path[0] == 0) {
 	getcwd(path, sizeof(path));
-	strlcat(path, "/po", sizeof(path));
+	strncat(path, "/po", sizeof(path) - strlen(path) - 1);
     }
 
     const char *lname = setlocale(LC_MESSAGES, lang);


### PR DESCRIPTION
Fix building libxo on Linux with a modern toolchain (GCC 16 / C23, parallel `make`, glibc).

### Linux build failures & root causes
- **C23**: `bool` is used as an identifier in the XPath filter, which C23 makes a keyword. Renamed the locals (`filter/xo_filter.c`).
- **strlcpy/strlcat**: not portably declared (glibc does not expose them without `_DEFAULT_SOURCE`), so they were left undefined at link. Replaced with standard `snprintf`/`strncat` (`libxo/xo_syslog.c`, `tests/gettext/gt_01.c`).
- **Parallel build race**: `xo_xpath.{o,lo}` include the generated `xo_xpath.tab.h` but had no prerequisite on it, racing under `make -j`. Added the dependency (`filter/Makefile.am`).
- **gettext/msgfmt**: detection assumed a separate `libintl`; on glibc gettext lives in libc, so the `-lintl` probes failed and the `msgfmt` check aborted even when gettext is usable. Detect whether `-lintl` is needed, add `<stddef.h>` so `NULL` is defined, gate the `msgfmt` lookup on gettext being present, and also search `PATH`. Overlaps #114 and #115 — their fixes are incorporated/credited here.
- **YACC**: the grammar relies on byacc extensions (reentrant parser exposing `yystate` + byacc-generated tables) that GNU bison does not provide. Removed the misleading `bison -y` fallback and made `configure` fail clearly when byacc is unavailable.

### Validation
Linux, GCC 16, byacc: bootstrap + `configure` (gettext enabled on glibc) + parallel `make -j4` + `make test` all pass. `configure YACC=bison` now fails with a clear "byacc is required" error. macOS/FreeBSD are unaffected (their `yacc` is byacc).

### References
- #114, #115
- Downstream reproducer: Homebrew/homebrew-core#297355
