### PR TITLE
tests: only include bsd/string.h when configure found it

### DIFF
--- a/tests/gettext/gt_01.c
+++ b/tests/gettext/gt_01.c
@@ -23,9 +23,9 @@
 
 #include "xo_config.h"
 
-#ifdef HAVE_GCC
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
-#endif /* HAVE_GCC */
+#endif /* HAVE_BSD_STRING_H */
 
 #include "xo.h"
 #include "xo_encoder.h"


### PR DESCRIPTION
`tests/gettext/gt_01.c` includes `<bsd/string.h>` under `#ifdef HAVE_GCC`, so on glibc systems without libbsd the gettext test fails to compile:

    gt_01.c:27:10: fatal error: bsd/string.h: No such file or directory

`libxo/xo_string.h` already guards the same include with `HAVE_BSD_STRING_H`, which configure sets via `AC_CHECK_HEADERS([bsd/string.h])`. Use the same guard in the test.

Seen while packaging 2.1.0 for Homebrew on Linux